### PR TITLE
media query hotfix on 768px width device

### DIFF
--- a/src/vue-event-calendar.vue
+++ b/src/vue-event-calendar.vue
@@ -172,7 +172,7 @@ export default {
     }
   }
 }
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 767px) {
   .__vev_calendar-wrapper{
     .cal-wrapper{
       width: 100%;


### PR DESCRIPTION
the calendar become overlapped the event panel which cause by a wrong size media query